### PR TITLE
Make TestCase action field optional

### DIFF
--- a/lib/src/test_case/negative.test_case.dart
+++ b/lib/src/test_case/negative.test_case.dart
@@ -93,7 +93,7 @@ class NegativeTestCase<INPUT extends Object?, OUTPUT extends Object?>
     test(
       description,
       () => expect(
-        () => action(input),
+        () => action?.call(input),
         matcher,
       ),
     );

--- a/lib/src/test_case/test_case.dart
+++ b/lib/src/test_case/test_case.dart
@@ -67,7 +67,7 @@ class TestCase<INPUT extends Object?, OUTPUT extends Object?> {
   /// Provided only if the [TestCase] is executed without a [TestGroup].
   /// If [TestGroup] is provided, the common [action] is run by just varying the input.
   ///
-  final ParameterizedCallback<INPUT, OUTPUT?> action;
+  final ParameterizedCallback<INPUT, OUTPUT>? action;
 
   ///
   /// Direct forward to [test] function
@@ -108,14 +108,14 @@ class TestCase<INPUT extends Object?, OUTPUT extends Object?> {
     required this.then,
     required this.input,
     required this.matcher,
-    ParameterizedCallback<INPUT, OUTPUT>? action,
+    this.action,
     this.testOn,
     this.timeout,
     this.skip,
     this.tags,
     this.onPlatform,
     this.retry,
-  }) : action = action ?? ((INPUT input) => null);
+  });
 
   ///
   /// [copyWith] is used internally by the [TestGroup].
@@ -145,7 +145,7 @@ class TestCase<INPUT extends Object?, OUTPUT extends Object?> {
     test(
       description,
       () => expect(
-        action(input),
+        action?.call(input),
         matcher,
       ),
       testOn: this.testOn,

--- a/test/test_case_test.dart
+++ b/test/test_case_test.dart
@@ -10,22 +10,15 @@ void main() {
       then: 'outputs value in m',
       input: 1.0,
       matcher: equals('0.01 m'),
+      action: (double input) => Height(input).toStringInMetre(),
     );
 
     test(
-        'When action is not provided to the TestCase, It should be defaulted to null returning dummy function.',
-        () {
-      expect(testCase.action(1), null);
-    });
-
-    final newTestCase =
-        testCase.copyWith((double input) => Height(input).toStringInMetre());
-    test(
         'When copied with a new action, all other fields should remain the same.',
         () {
-      expect(newTestCase.when, 'Positive Border height value');
-      expect(newTestCase.then, 'outputs value in m');
-      expect(newTestCase.input, 1);
+      expect(testCase.when, 'Positive Border height value');
+      expect(testCase.then, 'outputs value in m');
+      expect(testCase.input, 1);
     });
 
     test('Description should be built using when and then.', () {


### PR DESCRIPTION
## Description
- Make TestCase action field optional.
- Handle null in TestCase.execute as a result optional action.
- Handle null in NegativeTestCase.execute as a result optional action.
- Remove an unwanted test in test_case_test.dart.

## Components Changed
1. TestCase
2. NegativeTestCase
3. test_case_test.dart

## Change Type
Patch

## Fixes
#4 

## Checklist
- [ ] Requires dependency update?
